### PR TITLE
Fallback for missing register-level <access>

### DIFF
--- a/generate_registers.clj
+++ b/generate_registers.clj
@@ -190,11 +190,12 @@
                      (= access "write-only")
                      (str "RegisterRW(" "void, " type-name ")")
 
-                     (and (= access "read-write") separate-read-write-types?)
+                     (and (or (nil? access) (= access "read-write")) separate-read-write-types?)
                      (str "RegisterRW(" type-name "_read, " type-name "_write)")
 
-                     (and (= access "read-write") (not separate-read-write-types?))
+                     (and (or (nil? access) (= access "read-write")) (not separate-read-write-types?))
                      (str "Register(" type-name ")"))
+
 
                    (if (and dim dimIncrement)
                      (let [dim (hex->int dim)


### PR DESCRIPTION
In the SVD for stm32f103[1] there are registers where the `<access>` is declared per-field rather than for the whole register.

This caused `nil` instead of Register to be emitted:

```
pub const cr = nil(cr_val).init(0x40021000 + 0x0);
```

This change makes those register be treated like read-write even though some of the contained fields are read-only.

[1] https://www.st.com/resource/en/svd/stm32f1_svd.zip